### PR TITLE
Gitlab

### DIFF
--- a/slides/_git_fundamentals.qmd
+++ b/slides/_git_fundamentals.qmd
@@ -158,6 +158,10 @@ un bon `.gitignore`)
 
 ## Modes d'authentification
 
+::: {.panel-tabset}
+
+## {{< fa brands github >}}
+
 :::{.incremental}
 - [**https**]{.orange}
   - `git clone https://github.com/username/projet.git`
@@ -168,6 +172,27 @@ un bon `.gitignore`)
   - `git clone git@github.com:username/projet.git`
   - (plus) complexe à initialiser
   - authentification automatique 
+:::
+
+## {{< fa brands gitlab >}} insee
+
+::: {style="font-size: 75%;"}
+
+:::{.incremental }
+
+- [**https**]{.orange}
+  - `git clone https://gitlab.insee.fr/username_or_groupname/projet.git`
+  - simple à utiliser
+  - authentification username + password (ou token) à chaque *push*
+
+- [**ssh**]{.orange}
+  - `git clone git@gitlab.insee.fr:username_or_groupname/projet.git`
+  - (plus) complexe à initialiser
+  - authentification automatique 
+:::
+
+:::
+
 :::
 
 ## Application 0 {.smaller}

--- a/slides/applications_git/_application0.qmd
+++ b/slides/applications_git/_application0.qmd
@@ -1,4 +1,9 @@
+::: {.panel-tabset}
+
+## {{< fa brands github >}} 
+
 :::{.callout-tip collapse="true" icon=false}
+
 ## Préparation de l'environnement de travail
 
 :::{.incremental}
@@ -10,8 +15,33 @@
     + `File` → `New project` → `Version Control` → `Git`
 6. [Générer un *token*](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) (jeton d'authentification) sur `GitHub`
 7. Stocker le *token* sur le `SSP Cloud` (ou un gestionnaire de mot de passe) :
-    + `Mon Compte` -> `Services externes` -> `Jeton d'accès personnel GitHub`
+    + `Mon Compte` -> `Git` -> `Token d'accès personnel pour Forge Git`
 8. Terminer la procédure de clonage en fournissant le nom d'utilisateur `GitHub` et le *token*
+
+:::
+
+:::
+
+## {{< fa brands gitlab >}} insee
+
+:::{.callout-tip collapse="true" icon=false}
+
+## Préparation de l'environnement de travail
+
+:::{.incremental}
+1. Compte déjà créé sur le [gitlab interne](https://gitlab.insee.fr/)
+2. Créer un nouveau dépôt **privé** sur `gitlab.insee.fr`
+3. Créer un compte sur [LS3](https://datalab.sspcloud.fr/home) via AUS.
+4. Lancer un service `RStudio`. Dans l'onglet de configuration `Git` du service, fixer la durée du `Cache` pour le stockage des identifiants `Gitlab` à une valeur suffisamment élevée
+5. Cloner le dépôt distant sur votre environnement local (ici, le `RStudio` de la plateforme `LS3`):
+    + `File` → `New project` → `Version Control` → `Git`
+6. [Générer un *token*](https://gitlab.insee.fr/mobitic/book_qualite/-/settings/access_tokens) (jeton d'authentification) sur `gitlab.insee.fr`
+7. Stocker le *token* sur `LS3` (ou un gestionnaire de mot de passe) :
+    + `Mon Compte` -> `Git` -> `Token d'accès personnel pour Forge Git`
+8. Terminer la procédure de clonage en fournissant le nom d'utilisateur `gitlab.insee.fr` (code insee en 6 caractères) et le *token*
+
+:::
+
 :::
 
 :::

--- a/slides/applications_git/_application1.qmd
+++ b/slides/applications_git/_application1.qmd
@@ -13,4 +13,4 @@
 :::
 :::
 
-❓ **Question** : à ce stade, le dépôt du projet sur `GitHub` (`remote`) a-t-il été modifié ?
+❓ **Question** : à ce stade, le dépôt du projet sur `GitHub` / `Gitlab` (`remote`) a-t-il été modifié ?

--- a/slides/applications_git/_application2.qmd
+++ b/slides/applications_git/_application2.qmd
@@ -4,7 +4,7 @@
 
 ::: {.incremental}
 1. Effectuer un `push` pour intégrer les changements locaux au projet distant
-2. Parcourir l'historique du projet sur `GitHub`
+2. Parcourir l'historique du projet sur `GitHub` / `Gitlab`
     a. Faire apparaître les différences entre deux versions consécutives du projet
     b. Afficher une version passée du projet
 :::

--- a/slides/applications_git/_application3.qmd
+++ b/slides/applications_git/_application3.qmd
@@ -2,7 +2,7 @@
 ## Le fichier `.gitignore`
 
 ::: {.incremental}
-Lors de la création du projet sur `GitHub`, nous avons demandé la création d'un fichier `.gitignore`, qui se situe à la racine du projet. Il spécifie l'ensemble des fichiers qui seront toujours exclus de l'indexation faite par `Git`.
+Lors de la création du projet sur `GitHub` / `Gitlab`, nous avons demandé la création d'un fichier `.gitignore`, qui se situe à la racine du projet. Il spécifie l'ensemble des fichiers qui seront toujours exclus de l'indexation faite par `Git`.
 
 1. Exclure les fichiers de type `*.pdf` et `*.html`
 2. Créer un dossier `data` à la racine du projet et créer à l'intérieur de celui-ci un fichier `data/raw.csv` avec une ligne de données quelconque

--- a/slides/applications_git/_application4a.qmd
+++ b/slides/applications_git/_application4a.qmd
@@ -5,7 +5,7 @@
 1. Se mettre par [__groupes de 3/4 personnes__]{.orange}:
     - Une personne aura la responsabilité d’être [**mainteneur**]{.blue2}
     - Deux à trois personnes seront [**développeurs**]{.blue2}
-2. Le mainteneur crée un dépôt sur `Github`. Il/Elle donne des droits au(x) développeur(s) du projet
+2. Le mainteneur crée un dépôt sur `Github` / `Gitlab`. Il/Elle donne des droits au(x) développeur(s) du projet
 3. Créer une copie locale (clone) du projet sur son service `RStudio` du [Datalab](https://datalab.sspcloud.fr/home)
 4. Créer un fichier `<votre_nom>-<votre_prenom>.md`. Écrire dedans trois phrases de son choix sans ponctuation ni majuscules, puis `commit` et `push` les modifications
 5. __À ce stade, une seule personne (la plus rapide) devrait ne pas avoir rencontré de rejet du `push`.__

--- a/slides/applications_git/_application6.qmd
+++ b/slides/applications_git/_application6.qmd
@@ -2,7 +2,7 @@
 ## Branches, *issues* et *pull requests*
 
 ::: {.incremental}
-1. Sur `GitHub`, chaque personne ouvre une `Issue` sur le même dépôt que les applications précédentes, dans laquelle vous suggérez une modification à apporter à votre projet
+1. Sur `Github` / `Gitlab`, chaque personne ouvre une `Issue` sur le même dépôt que les applications précédentes, dans laquelle vous suggérez une modification à apporter à votre projet
 2. Créer une branche dont le nom indique la modification que vous allez apporter (ex : `ajout-authentification`)
 3. Effectuer un `commit` avec les modifications de votre choix, puis pousser les changements sur une nouvelle branche du dépôt distant
 4. Ouvrir une `Pull Request` (`PR`) pour proposer d'intégrer vos changements sur la branche principale du dépôt distant. Spécifier que l'acceptation de la `Pull Request` entraînera la fermeture automatique de l'`Issue` associée en écrivant dans le corps de la `PR` : `close #N` où `N` est le numéro de l'`Issue` en question

--- a/slides/applications_git/_application7.qmd
+++ b/slides/applications_git/_application7.qmd
@@ -4,7 +4,7 @@
 ::: {.incremental}
 Cette application vise à prendre en matin l'interface de `GitLab`, éventuellement dans le cadre de votre environnement interne de travail.
 
-1. Dans le cadre d'un `GitLab` interne, il est plus confortable d'utiliser l'authentification via clé `ssh` plutôt que l'authentification par *token*. Si vous n'en avez pas encore, générer une clé `ssh` et ajouter celle-ci à votre compte `GitLab`. Se référer pour cela à la [documentation GitLab](https://docs.gitlab.com/ee/user/ssh.html) ou, idéalement, à la documentation de cette procédure sur votre environnement interne de travail.
+1. Dans le cadre d'un `GitLab` interne (hors LS3), il est plus confortable d'utiliser l'authentification via clé `ssh` plutôt que l'authentification par *token*. Si vous n'en avez pas encore, générer une clé `ssh` et ajouter celle-ci à votre compte `GitLab`. Se référer pour cela à la [documentation GitLab](https://docs.gitlab.com/ee/user/ssh.html) ou, idéalement, à la documentation de cette procédure sur votre environnement interne de travail.
 2. Explorer l'interface de `GitLab` pour retrouver les différents éléments que nous avons exploités sur l'interface de `GitHub`.
 3. Créer un projet dans son espace personnel sur `GitLab` et répéter les opérations des applications 1 et 2.
 :::


### PR DESCRIPTION
On m'a dit que certains stagiaires tiquent sur le fait de devoir faire la formation bonnes pratiques en dehors de leur environnement de travail habituel (AUS). 
Je propose, essentiellement pour les applications, de fournir la démarche adaptée à LS3 dans des tabset-panels.
Certes, ce n'est pas AUS desktop (pour les plus chagrins), mais ça a le mérite de montrer la démarche avec gitlab.insee.fr au lieu de github.com et LS3 plutôt que le SSPcloud.
ça ne retire rien au contenu des slides.
En revanche, on évoque dans ces tabsets des cas d'utilisation uniquement à destination des personnes sur le réseau Insee.
Pas sûr que cette formule fasse concensus du coup.
Une alternative aurait pu être de forker la formation toute entière et de la déployer sur une autre URL (mais ça me semble disproportionné pour les petites modifications apportées). 
